### PR TITLE
feat: add `X-React-Native-Project-Root` header to dev server

### DIFF
--- a/packages/vxrn/src/vendor/repack/dev-server/src/createServer.ts
+++ b/packages/vxrn/src/vendor/repack/dev-server/src/createServer.ts
@@ -105,6 +105,7 @@ export async function createServer(config: Server.Config) {
 
   instance.addHook('onSend', async (request, reply, payload) => {
     reply.header('X-Content-Type-Options', 'nosniff')
+    reply.header('X-React-Native-Project-Root', config.options.rootDir)
 
     const [pathname] = request.url.split('?')
     if (pathname.endsWith('.map')) {


### PR DESCRIPTION
### Summary

To properly support `@react-native-community/cli` a dev server needs to return a header called `X-React-Native-Project-Root` with path to the project root. 

#### Before:

```
❯ yarn ios
yarn run v1.22.19
$ react-native run-ios
info Another process is running on port 8081.
? Use port 8082 instead? › - Use arrow-keys. Return to submit.
❯   Yes
    No
```


#### After:
```
❯ yarn ios
yarn run v1.22.19
$ react-native run-ios
info A dev server is already running for this project on port 8081.
```

### Test plan 
1. Bootstrap project with `npx react-native@latest init`
2. Do all necessary steps to setup `vxrn` inside project 
3. Start a dev server, and run `yarn ios` -> RN CLI should detect dev server on selected port.