### PR TITLE
fix(swc): path to `react-refresh`

### DIFF
--- a/packages/vite-native-swc/src/index.ts
+++ b/packages/vite-native-swc/src/index.ts
@@ -163,7 +163,7 @@ export function wrapSourceInRefreshRuntime(id: string, code: string, options: Op
   `
       : ``
 
-  return `const RefreshRuntime = __cachedModules["react-native/node_modules/react-refresh/cjs/react-refresh-runtime.development"];
+  return `const RefreshRuntime = __cachedModules["react-refresh/cjs/react-refresh-runtime.development"];
 const prevRefreshReg = globalThis.$RefreshReg$;
 const prevRefreshSig = globalThis.$RefreshSig$;
 globalThis.$RefreshReg$ = (type, id) => RefreshRuntime.register(type, "${id}" + " " + id);


### PR DESCRIPTION
### Summary

In this Pull Request I've fixed a bug with swc in bare `@react-native-community/cli` setup:

![CleanShot 2024-02-05 at 13 20 27](https://github.com/natew/vxrn/assets/63900941/b625a9b7-94e2-4a98-8b48-5d675f7978cd)

While receiving bundle from a server, it had problem with `react-refresh` package, after digging into codebase I found that that a path to package is wrong and that's why it couldn't read `createSignatureFunctionForTransform`.