### PR TITLE
chore: remove debugger app

### DIFF
--- a/examples/bare/tsconfig.json
+++ b/examples/bare/tsconfig.json
@@ -1,9 +1,3 @@
 {
-  "compilerOptions": {
-    "paths": {
-      "tamagui": ["../tamagui"],
-      "@tamagui/*": ["../../packages/*"]
-    }
-  },
   "extends": "../../tsconfig"
 }

--- a/examples/expo-router/tsconfig.json
+++ b/examples/expo-router/tsconfig.json
@@ -1,9 +1,3 @@
 {
-  "compilerOptions": {
-    "paths": {
-      "tamagui": ["../tamagui"],
-      "@tamagui/*": ["../../packages/*"]
-    },
-  },
   "extends": "../../tsconfig"
 }

--- a/examples/tamagui/tsconfig.json
+++ b/examples/tamagui/tsconfig.json
@@ -1,9 +1,3 @@
 {
-  "compilerOptions": {
-    "paths": {
-      "tamagui": ["../tamagui"],
-      "@tamagui/*": ["../../packages/*"]
-    },
-  },
   "extends": "../../tsconfig"
 }

--- a/packages/vxrn/package.json
+++ b/packages/vxrn/package.json
@@ -4,7 +4,6 @@
   "source": "src/index.ts",
   "types": "./types/index.d.ts",
   "main": "dist",
-  "tamagui-publish-skip": true,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/vxrn/package.json
+++ b/packages/vxrn/package.json
@@ -22,7 +22,6 @@
   },
   "dependencies": {
     "@babel/code-frame": "^7.21.4",
-    "@callstack/repack-debugger-app": "^1.0.0",
     "@fastify/sensible": "^4.1.0",
     "@fastify/static": "^5.0.2",
     "@vitejs/plugin-react": "^4.0.4",

--- a/packages/vxrn/src/create.ts
+++ b/packages/vxrn/src/create.ts
@@ -47,7 +47,7 @@ export const create = async (options: StartOptions) => {
       react(),
 
       {
-        name: 'tamagui-client-transform',
+        name: 'client-transform',
 
         async handleHotUpdate({ read, modules, file }) {
           try {
@@ -400,15 +400,16 @@ ___modules___["${outputModule.fileName}"] = ((exports, module) => {
   ${outputModule.code}
 })
 
-${outputModule.isEntry
-              ? `
+${
+  outputModule.isEntry
+    ? `
 // run entry
 const __require = createRequire({})
 __require("react-native")
 __require("${outputModule.fileName}")
 `
-              : ''
-            }
+    : ''
+}
 `
         }
       })

--- a/packages/vxrn/src/dev/createDevServer.ts
+++ b/packages/vxrn/src/dev/createDevServer.ts
@@ -1,6 +1,6 @@
 import mime from 'mime/lite'
 
-import { HMRListener, StartOptions } from '../types'
+import { HMRListener } from '../types'
 import { DEFAULT_PORT } from '../utils/constants'
 import { Server, createServer } from '../vendor/repack/dev-server/src'
 

--- a/packages/vxrn/src/nativePlugin.ts
+++ b/packages/vxrn/src/nativePlugin.ts
@@ -25,7 +25,7 @@ export function nativePlugin(options: {
   mode: 'build' | 'serve'
 }): Plugin {
   return {
-    name: 'tamagui-native',
+    name: 'native',
     enforce: 'pre',
 
     config: async (config) => {

--- a/packages/vxrn/src/vendor/repack/dev-server/src/createServer.ts
+++ b/packages/vxrn/src/vendor/repack/dev-server/src/createServer.ts
@@ -1,6 +1,5 @@
 import { Writable } from 'stream'
 
-// import debuggerAppPath from '@callstack/repack-debugger-app'
 import fastifySensible from '@fastify/sensible'
 import fastifyStatic from '@fastify/static'
 import Fastify from 'fastify'
@@ -89,14 +88,6 @@ export async function createServer(config: Server.Config) {
   })
   await instance.register(devtoolsPlugin, {
     options: config.options,
-  })
-
-  const debuggerAppPath = (await import('@callstack/repack-debugger-app')).default
-
-  await instance.register(fastifyStatic, {
-    root: debuggerAppPath,
-    prefix: '/debugger-ui',
-    prefixAvoidTrailingSlash: true,
   })
 
   // below is to prevent showing `GET 400 /favicon.ico`

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -54,7 +54,6 @@ const nextVersion = (() => {
   return next
 })()
 
-
 if (!finish) {
   if (!skipVersion) {
     console.info('Publishing version:', nextVersion, '\n')
@@ -84,10 +83,10 @@ async function run() {
       location: string
     }[]
 
-    const allPackageJsons = (
+    const packageJsons = (
       await Promise.all(
         packagePaths
-          .filter((i) => i.location !== '.' && !i.name.startsWith('@takeout'))
+          .filter((i) => i.location !== '.')
           .map(async ({ name, location }) => {
             const cwd = path.join(process.cwd(), location)
             const json = await fs.readJSON(path.join(cwd, 'package.json'))
@@ -100,19 +99,7 @@ async function run() {
             }
           })
       )
-    ).filter((x) => !x.json['publish-skip'])
-
-    const packageJsons = allPackageJsons
-      .filter((x) => {
-        return !x.json.private
-      })
-      // slow things last
-      .sort((a, b) => {
-        if (a.name.includes('font-') || a.name.includes('-icons')) {
-          return 1
-        }
-        return -1
-      })
+    ).filter((pkg) => !pkg.json.private)
 
     console.info(`Publishing in order:\n\n${packageJsons.map((x) => x.name).join('\n')}`)
 
@@ -135,11 +122,11 @@ async function run() {
       isCI || skipVersion
         ? { version: nextVersion }
         : await prompts({
-          type: 'text',
-          name: 'version',
-          message: 'Version?',
-          initial: nextVersion,
-        })
+            type: 'text',
+            name: 'version',
+            message: 'Version?',
+            initial: nextVersion,
+          })
 
     version = answer.version
 
@@ -174,7 +161,7 @@ async function run() {
 
     if (!skipVersion && !finish) {
       await Promise.all(
-        allPackageJsons.map(async ({ json, path }) => {
+        packageJsons.map(async ({ json, path }) => {
           const next = { ...json }
 
           next.version = version

--- a/yarn.lock
+++ b/yarn.lock
@@ -2264,13 +2264,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@callstack/repack-debugger-app@npm:^1.0.0":
-  version: 1.0.2
-  resolution: "@callstack/repack-debugger-app@npm:1.0.2"
-  checksum: 8d017b4695de0717c62d3ce0d4ca7d58a87c8e00609e89531b096907d374c5a7cb89da7e2be462a2df85b1ff61a365223418a4ad3967acbc7d4bb95df1b4dab2
-  languageName: node
-  linkType: hard
-
 "@changesets/types@npm:^4.0.1":
   version: 4.1.0
   resolution: "@changesets/types@npm:4.1.0"
@@ -16219,7 +16212,6 @@ __metadata:
   resolution: "vxrn@workspace:packages/vxrn"
   dependencies:
     "@babel/code-frame": ^7.21.4
-    "@callstack/repack-debugger-app": ^1.0.0
     "@fastify/sensible": ^4.1.0
     "@fastify/static": ^5.0.2
     "@tamagui/build": latest


### PR DESCRIPTION
From React Native 0.73 there's a new Chrome Debugger - and the remote JS debugging is already deprecated.  