### PR TITLE
feat: add handling keypress inputs

### DIFF
--- a/packages/vxrn/package.json
+++ b/packages/vxrn/package.json
@@ -44,6 +44,7 @@
     "mime": "^3.0.0",
     "open-editor": "^4.1.1",
     "pretty-format": "^28.1.0",
+    "readline": "^1.3.0",
     "rollup": "^3.29.4",
     "source-map": "^0.7.3",
     "url": "^0.11.0",

--- a/packages/vxrn/src/dev/bindKeypressInput.ts
+++ b/packages/vxrn/src/dev/bindKeypressInput.ts
@@ -1,0 +1,37 @@
+import { Server } from '../vendor/repack/dev-server/src'
+import readline from 'readline'
+
+export function bindKeypressInput(ctx: Server.DelegateContext) {
+  if (!process.stdin.setRawMode) {
+    ctx.log.warn({
+      msg: 'Interactive mode is not supported in this environment',
+    })
+    return
+  }
+
+  readline.emitKeypressEvents(process.stdin)
+  process.stdin.setRawMode(true)
+
+  process.stdin.on('keypress', (_key, data) => {
+    const { ctrl, name } = data
+    if (ctrl === true) {
+      switch (name) {
+        case 'c':
+          process.exit()
+        case 'z':
+          process.emit('SIGTSTP', 'SIGTSTP')
+          break
+      }
+    } else if (name === 'r') {
+      ctx.broadcastToMessageClients({ method: 'reload' })
+      ctx.log.info({
+        msg: 'Reloading app',
+      })
+    } else if (name === 'd') {
+      ctx.broadcastToMessageClients({ method: 'devMenu' })
+      ctx.log.info({
+        msg: 'Opening developer menu',
+      })
+    }
+  })
+}

--- a/packages/vxrn/src/dev/bindKeypressInput.ts
+++ b/packages/vxrn/src/dev/bindKeypressInput.ts
@@ -22,16 +22,25 @@ export function bindKeypressInput(ctx: Server.DelegateContext) {
           process.emit('SIGTSTP', 'SIGTSTP')
           break
       }
-    } else if (name === 'r') {
-      ctx.broadcastToMessageClients({ method: 'reload' })
-      ctx.log.info({
-        msg: 'Reloading app',
-      })
-    } else if (name === 'd') {
-      ctx.broadcastToMessageClients({ method: 'devMenu' })
-      ctx.log.info({
-        msg: 'Opening developer menu',
-      })
+    } else {
+      switch (name) {
+        case 'r':
+          ctx.broadcastToMessageClients({ method: 'reload' })
+          ctx.log.info({
+            msg: 'Reloading app',
+          })
+          break
+        case 'd':
+          ctx.broadcastToMessageClients({ method: 'devMenu' })
+          ctx.log.info({
+            msg: 'Opening developer menu',
+          })
+          break
+        case 'c':
+          process.stdout.write('\u001b[2J\u001b[0;0H')
+          // TODO: after logging we should print information about port and host
+          break
+      }
     }
   })
 }

--- a/packages/vxrn/src/dev/createDevServer.ts
+++ b/packages/vxrn/src/dev/createDevServer.ts
@@ -3,6 +3,7 @@ import mime from 'mime/lite'
 import { HMRListener } from '../types'
 import { DEFAULT_PORT } from '../utils/constants'
 import { Server, createServer } from '../vendor/repack/dev-server/src'
+import { bindKeypressInput } from './bindKeypressInput'
 
 export async function createDevServer(
   options: {
@@ -36,9 +37,7 @@ export async function createDevServer(
     },
 
     delegate: (ctx): Server.Delegate => {
-      // if (args.interactive) {
-      //   bindKeypressInput(ctx)
-      // }
+      bindKeypressInput(ctx)
 
       // if (reversePort && args.port) {
       //   runAdbReverse(ctx, args.port)
@@ -102,14 +101,6 @@ export async function createDevServer(
 
           inferPlatform: (uri) => {
             return 'ios'
-
-            const url = new URL(uri, 'protocol://domain')
-            if (!url.searchParams.get('platform')) {
-              const [, platform] = /^\/(.+)\/.+$/.exec(url.pathname) ?? []
-              return platform
-            }
-
-            return undefined
           },
         },
 

--- a/packages/vxrn/src/dev/createDevServer.ts
+++ b/packages/vxrn/src/dev/createDevServer.ts
@@ -101,6 +101,14 @@ export async function createDevServer(
 
           inferPlatform: (uri) => {
             return 'ios'
+
+            const url = new URL(uri, 'protocol://domain')
+            if (!url.searchParams.get('platform')) {
+              const [, platform] = /^\/(.+)\/.+$/.exec(url.pathname) ?? []
+              return platform
+            }
+
+            return undefined
           },
         },
 

--- a/packages/vxrn/types/dev/bindKeypressInput.d.ts
+++ b/packages/vxrn/types/dev/bindKeypressInput.d.ts
@@ -1,0 +1,3 @@
+import { Server } from '../vendor/repack/dev-server/src';
+export declare function bindKeypressInput(ctx: Server.DelegateContext): void;
+//# sourceMappingURL=bindKeypressInput.d.ts.map

--- a/yarn.lock
+++ b/yarn.lock
@@ -16236,6 +16236,7 @@ __metadata:
     mime: ^3.0.0
     open-editor: ^4.1.1
     pretty-format: ^28.1.0
+    readline: ^1.3.0
     rollup: ^3.29.4
     source-map: ^0.7.3
     url: ^0.11.0


### PR DESCRIPTION
added support for handling keypress inputs:
- `d` - to reload
- `r` - to refresh
- `c` - to clear terminal window 
- `ctrl + c` to quit the process 

https://github.com/natew/vxrn/assets/63900941/ebe5122f-3e08-460d-a2bd-2da97d406fc4

