### PR TITLE
fix: properly infer platform

### DIFF
--- a/packages/vxrn/src/dev/createDevServer.ts
+++ b/packages/vxrn/src/dev/createDevServer.ts
@@ -101,8 +101,6 @@ export async function createDevServer(
           },
 
           inferPlatform: (uri) => {
-            return 'ios'
-
             const url = new URL(uri, 'protocol://domain')
             if (!url.searchParams.get('platform')) {
               const [, platform] = /^\/(.+)\/.+$/.exec(url.pathname) ?? []


### PR DESCRIPTION
Let's not mock `ios` as platform.