### PR TITLE
fix(bare): main module name

### DIFF
--- a/examples/bare/index.js
+++ b/examples/bare/index.js
@@ -1,4 +1,4 @@
 import { AppRegistry } from 'react-native'
 import App from './src/App'
 
-AppRegistry.registerComponent('main', () => App)
+AppRegistry.registerComponent('bare', () => App)

--- a/examples/bare/jest.config.js
+++ b/examples/bare/jest.config.js
@@ -1,3 +1,3 @@
-module.exports = {
+export default {
   preset: 'react-native',
-};
+}


### PR DESCRIPTION
When building app with React Native Community CLI, app is looking for `bare` module, in this PR I changed the module name to correctly match one included in `AppDelegate.mm`
https://github.com/natew/vxrn/blob/9b9bfff2780cdb583b1f314b30c54b3f15ae4ce7/examples/bare/ios/bare/AppDelegate.mm#L9